### PR TITLE
Update transform sequence param naming and clean up packing/unpacking parameters

### DIFF
--- a/src/pollux/_src/data/data.py
+++ b/src/pollux/_src/data/data.py
@@ -81,7 +81,7 @@ class OutputData(eqx.Module):
     err: BatchedDataT = eqx.field(
         default_factory=lambda: jnp.array(0.0), converter=jnp.asarray
     )
-    preprocessor: AbstractPreprocessor = eqx.field(default=NullPreprocessor())
+    preprocessor: AbstractPreprocessor = eqx.field(default=NullPreprocessor())  # type: ignore[no-untyped-call]
     processed: bool = eqx.field(default=False)
 
     def __post_init__(self) -> None:

--- a/src/pollux/_src/models/transforms.py
+++ b/src/pollux/_src/models/transforms.py
@@ -203,29 +203,31 @@ class TransformSequence(AbstractTransform):
 
     transforms: tuple[AbstractSingleTransform, ...]
 
-    # Here, these are collected directly from the component transforms
-    param_priors: ParamPriorsTupleT = eqx.field(init=False, repr=False)
-    param_shapes: ParamShapesTupleT = eqx.field(init=False, repr=False)
-
     def __init__(self, transforms: tuple[AbstractSingleTransform, ...]):
         """Initialize a sequence of transforms."""
         if not transforms:
             msg = "At least one transform required"
             raise ModelValidationError(msg)
 
-        # Store parameter information as tuples (reusing existing names)
-        self.param_priors = tuple(
-            getattr(transform, "param_priors", ImmutableMap())
-            for transform in transforms
-        )
-        self.param_shapes = tuple(
-            getattr(transform, "param_shapes", ImmutableMap())
-            for transform in transforms
-        )
-
         # Set output size to the final transform's output size
         self.output_size = transforms[-1].output_size
         self.transforms = transforms
+
+    @property
+    def param_priors(self) -> ParamPriorsTupleT:
+        """Collect parameter priors from all transforms in the sequence."""
+        return tuple(
+            getattr(transform, "param_priors", ImmutableMap())
+            for transform in self.transforms
+        )
+
+    @property
+    def param_shapes(self) -> ParamShapesTupleT:
+        """Collect parameter shapes from all transforms in the sequence."""
+        return tuple(
+            getattr(transform, "param_shapes", ImmutableMap())
+            for transform in self.transforms
+        )
 
     def apply(
         self, latents: BatchedLatentsT, *args: dict[str, Any], **kwargs: Any

--- a/src/pollux/_src/models/transforms.py
+++ b/src/pollux/_src/models/transforms.py
@@ -3,6 +3,7 @@ TODO: fix the docstrings and typing?
 """
 
 __all__ = [
+    "AbstractSingleTransform",
     "AbstractTransform",
     "AffineTransform",
     "FunctionTransform",
@@ -59,6 +60,10 @@ class ShapeSpec:
 ParamPriorsT: TypeAlias = ImmutableMap[str, dist.Distribution]
 ParamShapesT: TypeAlias = ImmutableMap[str, ShapeSpec | tuple[int, ...]]
 
+# Tuples of parameters for TransformSequence
+ParamPriorsTupleT: TypeAlias = tuple[ParamPriorsT, ...]
+ParamShapesTupleT: TypeAlias = tuple[ParamShapesT, ...]
+
 
 class AbstractTransform(eqx.Module):
     """Base class defining the transform interface.
@@ -68,8 +73,11 @@ class AbstractTransform(eqx.Module):
     """
 
     output_size: int
-    param_priors: ParamPriorsT = eqx.field(converter=ImmutableMap)
-    param_shapes: ParamShapesT = eqx.field(converter=ImmutableMap)
+
+    # TODO: param_priors and param_shapes must be defined on any abstract subclass, but
+    # there is no way to define an abstract class property
+    # param_priors: ParamPriorsT | ParamPriorsTupleT
+    # param_shapes: ParamShapesT | ParamShapesTupleT
 
     @abc.abstractmethod
     def apply(self, latents: BatchedLatentsT, **params: Any) -> BatchedOutputT:
@@ -81,7 +89,7 @@ class AbstractTransform(eqx.Module):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_priors(
+    def get_expanded_priors(
         self, latent_size: int, data_size: int | None = None
     ) -> ParamPriorsT:
         """Get expanded parameter priors.
@@ -92,13 +100,16 @@ class AbstractTransform(eqx.Module):
         raise NotImplementedError
 
 
-class AbstractAtomicTransform(AbstractTransform):
+class AbstractSingleTransform(AbstractTransform):
     """Base class providing common functionality for atomic transforms.
 
-    Atomic transforms apply a single operation to convert latent vectors to outputs.
+    "Single" transforms apply a single operation to convert latent vectors to outputs.
     """
 
+    param_priors: ParamPriorsT = eqx.field(converter=ImmutableMap)
+    param_shapes: ParamShapesT = eqx.field(converter=ImmutableMap)
     transform: TransformFuncT
+
     _param_names: tuple[str, ...] = eqx.field(init=False, repr=False)
     _transform: TransformFuncT = eqx.field(init=False, repr=False)
     vmap: bool = True
@@ -132,7 +143,7 @@ class AbstractAtomicTransform(AbstractTransform):
             raise RuntimeError(msg) from e
         return self._transform(latents, *arg_params)
 
-    def get_priors(
+    def get_expanded_priors(
         self, latent_size: int, data_size: int | None = None
     ) -> ParamPriorsT:
         """Get expanded parameter priors.
@@ -166,101 +177,131 @@ class TransformSequence(AbstractTransform):
 
     Composes multiple transforms together, where the output of each transform
     becomes the input to the next transform in the sequence.
+
+    Parameters are stored as tuples of dictionaries, one element per transform.
     """
 
-    transforms: tuple[AbstractTransform, ...]
+    transforms: tuple[AbstractSingleTransform, ...]
 
-    def __init__(self, transforms: tuple[AbstractTransform, ...]):
-        """Initialize a sequence of transforms.
+    # Here, these are collected directly from the component transforms
+    param_priors: ParamPriorsTupleT = eqx.field(init=False, repr=False)
+    param_shapes: ParamShapesTupleT = eqx.field(init=False, repr=False)
 
-        Combines the parameter priors and shapes from all transforms in the sequence,
-        prefixing them with indices to maintain uniqueness.
-        """
+    def __init__(self, transforms: tuple[AbstractSingleTransform, ...]):
+        """Initialize a sequence of transforms."""
         if not transforms:
             msg = "At least one transform required"
             raise ModelValidationError(msg)
 
-        super().__init__(
-            output_size=transforms[-1].output_size,
-            param_priors=self._combine_priors(transforms),
-            param_shapes=self._combine_shapes(transforms),
+        # Store parameter information as tuples (reusing existing names)
+        self.param_priors = tuple(
+            getattr(transform, "param_priors", ImmutableMap())
+            for transform in transforms
         )
+        self.param_shapes = tuple(
+            getattr(transform, "param_shapes", ImmutableMap())
+            for transform in transforms
+        )
+
+        # Set output size to the final transform's output size
+        self.output_size = transforms[-1].output_size
         self.transforms = transforms
 
-    @staticmethod
-    def _combine_priors(transforms: tuple[AbstractTransform, ...]) -> ParamPriorsT:
-        """Combine parameter priors from multiple transforms."""
-        return ImmutableMap(
-            **{
-                f"t{i}_{name}": prior
-                for i, transform in enumerate(transforms)
-                for name, prior in transform.param_priors.items()
-            }
-        )
-
-    @staticmethod
-    def _combine_shapes(transforms: tuple[AbstractTransform, ...]) -> ParamShapesT:
-        """Combine parameter shapes from multiple transforms."""
-        return ImmutableMap(
-            **{
-                f"t{i}_{name}": shape
-                for i, transform in enumerate(transforms)
-                for name, shape in transform.param_shapes.items()
-            }
-        )
-
-    def apply(self, latents: BatchedLatentsT, **params: Any) -> BatchedOutputT:
+    def apply(
+        self, latents: BatchedLatentsT, *args: dict[str, Any], **kwargs: Any
+    ) -> BatchedOutputT:
         """Apply the sequence of transforms to input latent vectors.
 
-        Passes the input through each transform in sequence, routing the appropriate
-        parameters to each transform based on the prefixed parameter names.
+        Parameters can be provided in two ways:
+        1. As positional arguments: One dictionary per transform in sequence order
+        2. As keyword arguments: Using "{transform_index}:{param}" naming scheme, so a
+           parameter named "A" in transform 0 of the sequence would be "0:A".
+
+        Parameters
+        ----------
+        latents
+            Input latent vectors
+        *args
+            Parameter dictionaries, one per transform in the sequence
+        **kwargs
+            Flat parameters using the new naming scheme "{transform_index}:{param_name}"
         """
+        # Check if using positional parameter dictionaries
+        if args:
+            if len(args) != len(self.transforms):
+                msg = (
+                    f"Expected {len(self.transforms)} parameter dictionaries, "
+                    f"got {len(args)}"
+                )
+                raise ValueError(msg)
+
+            if kwargs:
+                msg = "Cannot mix positional parameter dicts with keyword parameters"
+                raise ValueError(msg)
+
+            output = latents
+            for transform, transform_params in zip(self.transforms, args):
+                output = transform.apply(output, **transform_params)
+            return output
+
+        # Handle flat format with "{index}:{param}" naming
+        transform_params_list: list[dict[str, Any]] = [{} for _ in self.transforms]
+
+        for param_name, param_value in kwargs.items():
+            if ":" in param_name:
+                # New format: "0:A", "1:p1", etc.
+                idx_str, actual_param_name = param_name.split(":", 1)
+                transform_idx = int(idx_str)
+                if not 0 <= transform_idx < len(self.transforms):
+                    msg = f"Invalid transform index: {transform_idx}"
+                    raise ValueError(msg)
+                transform_params_list[transform_idx][actual_param_name] = param_value
+
+            else:
+                # Handle any other parameter format as needed
+                msg = f"Unsupported parameter name format: {param_name}"
+                raise ValueError(msg)
+
         output = latents
-        for i, transform in enumerate(self.transforms):
-            transform_params = {
-                name.split("_")[1]: params[f"t{i}_{name.split('_')[1]}"]
-                for name in params
-                if name.startswith(f"t{i}_")
-            }
+        for transform, transform_params in zip(self.transforms, transform_params_list):
             output = transform.apply(output, **transform_params)
         return output
 
-    def get_priors(
+    # TODO: do we need to add new classmethods that pack or unpack parameter names from
+    # the {index}:{param} format to nested tuples and vice versa?
+
+    @property
+    def names_nested(self) -> tuple[tuple[str, ...], ...]:
+        return tuple(t._param_names for t in self.transforms)
+
+    @property
+    def names_flat(self) -> tuple[str, ...]:
+        return tuple(
+            f"{i}:{name}" for i, names in enumerate(self.names_nested) for name in names
+        )
+
+    def get_expanded_priors(
         self, latent_size: int, data_size: int | None = None
     ) -> ParamPriorsT:
-        """Get expanded parameter priors.
+        """Get expanded parameter priors using flat naming scheme.
 
-        Expands the parameter prior distributions to the concrete shapes needed
-        for the transform, based on latent size and optional data size.
+        Returns flattened parameter priors with index-based naming for
+        compatibility with the AbstractTransform interface.
+        Parameter names will be in the format: "{transform_index}:{param_name}"
         """
-        priors = {}
-        for name, prior in self.param_priors.items():
-            # Extract transform index from parameter name (e.g., "t0_A" -> 0)
-            transform_idx = int(
-                name.split("_")[0][1:]
-            )  # Remove 't' prefix and convert to int
-            trans = self.transforms[transform_idx]
 
-            if name in self.param_shapes:
-                shapespec = self.param_shapes[name]
-                shape = (
-                    shapespec.resolve(
-                        {
-                            "output_size": trans.output_size,
-                            "latent_size": latent_size,
-                            "data_size": data_size,
-                        }
-                    )
-                    if isinstance(shapespec, ShapeSpec)
-                    else shapespec
-                )
-                priors[name] = prior.expand(shape)
-            else:
-                priors[name] = prior
+        priors = {}
+        for i, transform in enumerate(self.transforms):
+            transform_priors = transform.get_expanded_priors(
+                latent_size=latent_size, data_size=data_size
+            )
+            for param_name, prior in transform_priors.items():
+                flat_name = f"{i}:{param_name}"
+                priors[flat_name] = prior
         return ImmutableMap(**priors)
 
 
-class FunctionTransform(AbstractAtomicTransform):
+class FunctionTransform(AbstractSingleTransform):
     """Function transformation using a user-defined function.
 
     This transform allows for arbitrary transformations defined by the user.
@@ -279,7 +320,7 @@ def _noop_transform(z: LatentsT) -> OutputT:
     return z
 
 
-class NoOpTransform(AbstractAtomicTransform):
+class NoOpTransform(AbstractSingleTransform):
     """No-op transformation."""
 
     output_size: int = 0
@@ -299,7 +340,7 @@ def _linear_transform(z: LatentsT, A: LinearT) -> OutputT:
     return A @ z
 
 
-class LinearTransform(AbstractAtomicTransform):
+class LinearTransform(AbstractSingleTransform):
     """Linear transformation from latent to output space.
 
     Implements the transformation: y = A @ z, where A is a matrix and z is a latent
@@ -327,7 +368,7 @@ def _offset_transform(z: LatentsT, b: OutputT) -> OutputT:
     return z + b
 
 
-class OffsetTransform(AbstractAtomicTransform):
+class OffsetTransform(AbstractSingleTransform):
     """Offset transformation that adds a bias vector to inputs.
 
     Implements the transformation: y = z + b, where b is a bias vector.
@@ -352,7 +393,7 @@ def _affine_transform(z: LatentsT, A: LinearT, b: OutputT) -> OutputT:
     return A @ z + b
 
 
-class AffineTransform(AbstractAtomicTransform):
+class AffineTransform(AbstractSingleTransform):
     """Affine transformation combining linear transform and offset.
 
     Implements the transformation: y = A @ z + b, where A is a matrix,
@@ -383,7 +424,7 @@ def _quadratic_transform(z: LatentsT, Q: QuadT, A: LinearT, b: OutputT) -> Outpu
     return jnp.einsum("i,oij,j->o", z, Q, z) + A @ z + b
 
 
-class QuadraticTransform(AbstractAtomicTransform):
+class QuadraticTransform(AbstractSingleTransform):
     """Quadratic transformation of latent vectors.
 
     Implements the transformation: y = z^T Q z + A @ z + b, where Q is a tensor,
@@ -409,7 +450,7 @@ class QuadraticTransform(AbstractAtomicTransform):
 # ----
 
 # TODO: implement a Gaussian Process transform using the tinygp library. The user should specify the kernel, and parameter priors for the kernel.
-# class GaussianProcessTransform(AtomicTransformMixin, AbstractTransform):
+# class GaussianProcessTransform(SingleTransformMixin, AbstractTransform):
 #     transform: TransformFuncT = ...
 
 
@@ -419,7 +460,7 @@ class QuadraticTransform(AbstractAtomicTransform):
 # # need to be a class factory so that the user can specify the layer shapes and
 # # activation functions and the class is constructed from that. Also, make it work with
 # # numpyro.
-# class MLPTransform(AtomicTransformMixin, AbstractTransform):
+# class MLPTransform(SingleTransformMixin, AbstractTransform):
 #     transform: TransformFuncT = eqx.field(
 #         default=lambda z, A, b: A @ z + b, init=False, repr=False
 #     )

--- a/src/pollux/_src/models/transforms.py
+++ b/src/pollux/_src/models/transforms.py
@@ -310,9 +310,12 @@ class TransformSequence(AbstractTransform):
         for param_name in self.names_flat:
             param_value = flat_params.get(param_name)
 
-            if param_value is None and not skip_missing:
-                msg = f"Missing value in transform: {param_name}"
-                raise ValueError(msg)
+            if param_value is None:
+                if not skip_missing:
+                    msg = f"Missing value in transform: {param_name}"
+                    raise ValueError(msg)
+                # Skip missing parameters when skip_missing=True
+                continue
 
             if ":" in param_name:
                 idx_str, actual_param_name = param_name.split(":", 1)

--- a/src/pollux/_src/typing.py
+++ b/src/pollux/_src/typing.py
@@ -3,7 +3,6 @@
 from collections.abc import Callable
 from typing import Any
 
-import jax
 from jax.example_libraries.optimizers import Optimizer
 from jaxtyping import Array, Float
 from numpyro.optim import _NumPyroOptim
@@ -24,8 +23,8 @@ TransformFuncT = Callable[..., OutputT]
 
 OptimizerT = _NumPyroOptim | Optimizer | Any
 
-PackedParamsT = dict[str, jax.Array]
-UnpackedParamsT = dict[str, dict[str, jax.Array] | jax.Array]
+PackedParamsT = dict[str, Any]
+UnpackedParamsT = dict[str, dict[str, Any] | Any | tuple[Any, ...]]
 
 __all__ = [
     "AnyShapeFloatT",

--- a/tests/integration/test_infer_distance.py
+++ b/tests/integration/test_infer_distance.py
@@ -59,7 +59,7 @@ def test_infer_distance():
     )
     model.register_output("label", trans)
 
-    params = {"flux": {"A": truth["B"]}, "label": {"0:A": truth["A"], "1:b": true_dm}}
+    params = {"flux": {"A": truth["B"]}, "label": [{"A": truth["A"]}, {"b": true_dm}]}
     test_out = model.predict_outputs(truth["latents"], params)
     assert jnp.allclose(test_out["flux"], truth["flux"], atol=1e-5)
     assert jnp.allclose(test_out["label"], truth["label"] + true_dm, atol=1e-5)
@@ -72,6 +72,6 @@ def test_infer_distance():
     )
     res.losses.block_until_ready()
 
-    d_dm = opt_params["label"]["1:b"] - true_dm
+    d_dm = opt_params["label"]["data"][1]["b"] - true_dm
     assert jnp.isclose(jnp.mean(d_dm), 0.0, atol=1e-1)
     assert jnp.isclose(jnp.std(d_dm), 1.0, atol=1e-1)

--- a/tests/integration/test_infer_distance.py
+++ b/tests/integration/test_infer_distance.py
@@ -59,7 +59,7 @@ def test_infer_distance():
     )
     model.register_output("label", trans)
 
-    params = {"flux": {"A": truth["B"]}, "label": {"t0_A": truth["A"], "t1_b": true_dm}}
+    params = {"flux": {"A": truth["B"]}, "label": {"0:A": truth["A"], "1:b": true_dm}}
     test_out = model.predict_outputs(truth["latents"], params)
     assert jnp.allclose(test_out["flux"], truth["flux"], atol=1e-5)
     assert jnp.allclose(test_out["label"], truth["label"] + true_dm, atol=1e-5)
@@ -72,6 +72,6 @@ def test_infer_distance():
     )
     res.losses.block_until_ready()
 
-    d_dm = opt_params["label"]["t1_b"] - true_dm
+    d_dm = opt_params["label"]["1:b"] - true_dm
     assert jnp.isclose(jnp.mean(d_dm), 0.0, atol=1e-1)
     assert jnp.isclose(jnp.std(d_dm), 1.0, atol=1e-1)

--- a/tests/integration/test_infer_unknown_errors.py
+++ b/tests/integration/test_infer_unknown_errors.py
@@ -61,5 +61,5 @@ def test_infer_error_intrinsic_scatter():
     res.losses.block_until_ready()
 
     assert np.isclose(
-        np.mean(opt_params["flux"]["s"]), np.mean(data["flux_err"]), atol=0.05
+        np.mean(opt_params["flux"]["err"]["s"]), np.mean(data["flux_err"]), atol=0.05
     )

--- a/tests/test_lux.py
+++ b/tests/test_lux.py
@@ -1,0 +1,415 @@
+import numpy as np
+import numpyro.distributions as dist
+import pytest
+
+import pollux as plx
+from pollux.models.transforms import (
+    FunctionTransform,
+    LinearTransform,
+    OffsetTransform,
+    TransformSequence,
+)
+
+
+@pytest.fixture()
+def rng():
+    """Random number generator for consistent test results."""
+    return np.random.default_rng(42)
+
+
+@pytest.fixture()
+def model_config():
+    """Basic model configuration used across tests."""
+    return {
+        "n_latents": 4,
+        "n_flux": 8,
+        "n_labels": 2,
+        "n_stars": 16,
+    }
+
+
+@pytest.fixture()
+def single_transform_model(model_config):
+    """LuxModel with a single LinearTransform for testing basic functionality."""
+    model = plx.LuxModel(latent_size=model_config["n_latents"])
+    model.register_output("flux", LinearTransform(output_size=model_config["n_flux"]))
+    return model
+
+
+@pytest.fixture()
+def single_transform_with_err_model(model_config):
+    """LuxModel with LinearTransform and OffsetTransform error transform."""
+    model = plx.LuxModel(latent_size=model_config["n_latents"])
+    model.register_output(
+        "flux",
+        LinearTransform(output_size=model_config["n_flux"]),
+        err_transform=OffsetTransform(output_size=model_config["n_flux"]),
+    )
+    return model
+
+
+@pytest.fixture()
+def transform_sequence_model(model_config):
+    """LuxModel with a TransformSequence (LinearTransform + OffsetTransform)."""
+    model = plx.LuxModel(latent_size=model_config["n_latents"])
+    trans_seq = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=model_config["n_flux"]),
+            OffsetTransform(output_size=model_config["n_flux"]),
+        )
+    )
+    model.register_output("flux", trans_seq)
+    return model
+
+
+@pytest.fixture()
+def transform_sequence_with_err_model(model_config):
+    """LuxModel with TransformSequence and a FunctionTransform error transform."""
+    model = plx.LuxModel(latent_size=model_config["n_latents"])
+
+    # Data transform: sequence of LinearTransform + OffsetTransform
+    trans_seq = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=model_config["n_flux"]),
+            OffsetTransform(output_size=model_config["n_flux"]),
+        )
+    )
+
+    # Error transform: simple scaling function
+    def scale_func(x, scale):
+        return x * scale
+
+    err_trans = FunctionTransform(
+        output_size=model_config["n_flux"],
+        transform=scale_func,
+        param_priors={"scale": dist.Normal(1.0, 0.1)},
+        param_shapes={"scale": (1,)},
+        vmap=False,
+    )
+
+    model.register_output("flux", trans_seq, err_transform=err_trans)
+    return model
+
+
+@pytest.fixture()
+def multi_output_model(model_config):
+    """LuxModel with multiple outputs: TransformSequence flux + single transform labels."""
+    model = plx.LuxModel(latent_size=model_config["n_latents"])
+
+    # Flux output: TransformSequence
+    flux_trans = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=model_config["n_flux"]),
+            OffsetTransform(output_size=model_config["n_flux"]),
+        )
+    )
+    model.register_output("flux", flux_trans)
+
+    # Label output: Single transform
+    model.register_output(
+        "label", LinearTransform(output_size=model_config["n_labels"])
+    )
+    return model
+
+
+class TestLuxModelParameterPackUnpack:
+    """Test suite for LuxModel parameter packing and unpacking functionality.
+
+    These tests verify the new two-dictionary parameter structure that separates
+    data transform parameters from error transform parameters. This design:
+    1. Prevents parameter name conflicts between data and error transforms
+    2. Maintains clean separation of concerns
+    3. Supports nested parameter structures for TransformSequence
+    4. Provides round-trip conversion integrity
+    """
+
+    def test_single_transform_basic(self, single_transform_model, model_config, rng):
+        """Test basic pack/unpack functionality with a single LinearTransform.
+
+        This test verifies the fundamental parameter conversion for the simplest case:
+        a single transform with no error parameters. It ensures that:
+        - Parameters are correctly packed into numpyro format ("flux:A")
+        - Parameters are correctly unpacked back to nested structure ({"flux": {"A": ...}})
+        - Round-trip conversion preserves data integrity
+        - Error parameters dictionary is properly initialized but empty
+        """
+        # Create test parameters using output-centric structure (err key optional)
+        A = rng.random((model_config["n_flux"], model_config["n_latents"]))
+        params = {"flux": {"data": {"A": A}}}
+
+        # Test packing
+        packed = single_transform_model.pack_numpyro_params(params)
+        expected_packed = {"flux:A": A}
+
+        assert set(packed.keys()) == set(expected_packed.keys())
+        assert np.allclose(packed["flux:A"], expected_packed["flux:A"])
+
+        # Test unpacking
+        unpacked = single_transform_model.unpack_numpyro_params(packed)
+
+        assert set(unpacked.keys()) == {"flux"}
+        assert set(unpacked["flux"].keys()) == {"data", "err"}
+        assert set(unpacked["flux"]["data"].keys()) == {"A"}
+        assert np.allclose(unpacked["flux"]["data"]["A"], A)
+        assert unpacked["flux"]["err"] == {}
+
+    def test_err_key_optional(self, single_transform_model, model_config, rng):
+        """Test that the 'err' key is optional when packing parameters.
+
+        This test verifies that when a model has no error parameters, users don't
+        need to specify an empty "err" key in the parameter structure. This makes
+        the API more convenient for the common case where error transforms are not used.
+        """
+        # Create test parameters WITHOUT the "err" key
+        A = rng.random((model_config["n_flux"], model_config["n_latents"]))
+        params_without_err = {"flux": {"data": {"A": A}}}
+
+        # Test packing - should work without "err" key
+        packed = single_transform_model.pack_numpyro_params(params_without_err)
+        expected_packed = {"flux:A": A}
+
+        assert set(packed.keys()) == set(expected_packed.keys())
+        assert np.allclose(packed["flux:A"], expected_packed["flux:A"])
+
+        # Unpacking should still include "err" key (even if empty)
+        unpacked = single_transform_model.unpack_numpyro_params(packed)
+        assert "err" in unpacked["flux"]
+        assert unpacked["flux"]["err"] == {}
+
+    def test_single_transform_with_error_params(
+        self, single_transform_with_err_model, model_config, rng
+    ):
+        """Test pack/unpack with single transform that has error transform parameters.
+
+        This test validates parameter handling when both data and error transforms are present
+        but both are single transforms (not sequences). It verifies:
+        - Data parameters use standard naming ("flux:A")
+        - Error parameters use prefixed naming ("flux:err:b")
+        - Both parameter types are correctly separated during unpacking
+        - No parameter name conflicts occur between data and error transforms
+        """
+        # Create test parameters using output-centric structure
+        A = rng.random((model_config["n_flux"], model_config["n_latents"]))
+        b = rng.random((model_config["n_flux"], 1))
+        params = {"flux": {"data": {"A": A}, "err": {"b": b}}}
+
+        # Test packing
+        packed = single_transform_with_err_model.pack_numpyro_params(params)
+        expected_keys = {"flux:A", "flux:err:b"}
+
+        assert set(packed.keys()) == expected_keys
+        assert np.allclose(packed["flux:A"], A)
+        assert np.allclose(packed["flux:err:b"], b)
+
+        # Test unpacking
+        unpacked = single_transform_with_err_model.unpack_numpyro_params(packed)
+
+        assert set(unpacked.keys()) == {"flux"}
+        assert set(unpacked["flux"].keys()) == {"data", "err"}
+        assert set(unpacked["flux"]["data"].keys()) == {"A"}
+        assert np.allclose(unpacked["flux"]["data"]["A"], A)
+
+        assert set(unpacked["flux"]["err"].keys()) == {"b"}
+        assert np.allclose(unpacked["flux"]["err"]["b"], b)
+
+    def test_transform_sequence_without_error(
+        self, transform_sequence_model, model_config, rng
+    ):
+        """Test pack/unpack with TransformSequence but no error transforms.
+
+        This test focuses on the core TransformSequence parameter handling:
+        - Data parameters use indexed naming ("flux:0:A", "flux:1:b")
+        - Parameters are unpacked into a list structure for each transform
+        - The list preserves the order and separation of transform parameters
+        - Error parameters remain empty but properly structured
+        """
+        # Create test parameters using output-centric structure (err key optional)
+        A = rng.random((model_config["n_flux"], model_config["n_latents"]))
+        b = rng.random((model_config["n_flux"], 1))
+        params = {"flux": {"data": [{"A": A}, {"b": b}]}}
+
+        # Test packing
+        packed = transform_sequence_model.pack_numpyro_params(params)
+        expected_keys = {"flux:0:A", "flux:1:b"}
+
+        assert set(packed.keys()) == expected_keys
+        assert np.allclose(packed["flux:0:A"], A)
+        assert np.allclose(packed["flux:1:b"], b)
+
+        # Test unpacking
+        unpacked = transform_sequence_model.unpack_numpyro_params(packed)
+
+        assert set(unpacked.keys()) == {"flux"}
+        assert set(unpacked["flux"].keys()) == {"data", "err"}
+        assert isinstance(unpacked["flux"]["data"], list | tuple)
+        assert len(unpacked["flux"]["data"]) == 2
+
+        assert set(unpacked["flux"]["data"][0].keys()) == {"A"}
+        assert set(unpacked["flux"]["data"][1].keys()) == {"b"}
+        assert np.allclose(unpacked["flux"]["data"][0]["A"], A)
+        assert np.allclose(unpacked["flux"]["data"][1]["b"], b)
+
+        assert unpacked["flux"]["err"] == {}
+
+    def test_transform_sequence_with_error_params(
+        self, transform_sequence_with_err_model, model_config, rng
+    ):
+        """Test pack/unpack with both TransformSequence and error transform parameters.
+
+        This test validates the most complex parameter scenario:
+        - TransformSequence data parameters use indexed naming ("flux:0:A", "flux:1:b")
+        - Error transform parameters use error-prefixed naming ("flux:err:scale")
+        - Data parameters are unpacked to list structure
+        - Error parameters are unpacked to flat dictionary structure
+        - Both parameter types coexist without conflicts
+        """
+        # Create test parameters using output-centric structure
+        A = rng.random((model_config["n_flux"], model_config["n_latents"]))
+        b = rng.random((model_config["n_flux"], 1))
+        scale = rng.random((1,))
+
+        params = {"flux": {"data": [{"A": A}, {"b": b}], "err": {"scale": scale}}}
+
+        # Test packing
+        packed = transform_sequence_with_err_model.pack_numpyro_params(params)
+        expected_keys = {"flux:0:A", "flux:1:b", "flux:err:scale"}
+
+        assert set(packed.keys()) == expected_keys
+        assert np.allclose(packed["flux:0:A"], A)
+        assert np.allclose(packed["flux:1:b"], b)
+        assert np.allclose(packed["flux:err:scale"], scale)
+
+        # Test unpacking
+        unpacked = transform_sequence_with_err_model.unpack_numpyro_params(packed)
+
+        # Check structure and data parameters (list structure)
+        assert set(unpacked.keys()) == {"flux"}
+        assert set(unpacked["flux"].keys()) == {"data", "err"}
+        assert isinstance(unpacked["flux"]["data"], list | tuple)
+        assert len(unpacked["flux"]["data"]) == 2
+        assert np.allclose(unpacked["flux"]["data"][0]["A"], A)
+        assert np.allclose(unpacked["flux"]["data"][1]["b"], b)
+
+        # Check error parameters (flat structure)
+        assert set(unpacked["flux"]["err"].keys()) == {"scale"}
+        assert np.allclose(unpacked["flux"]["err"]["scale"], scale)
+
+    def test_multiple_outputs_mixed_types(self, multi_output_model, model_config, rng):
+        """Test pack/unpack with multiple outputs having different transform types.
+
+        This test ensures the parameter system correctly handles models with mixed
+        output types simultaneously:
+        - One output uses TransformSequence (flux) with list-based parameters
+        - Another output uses single transform (label) with dict-based parameters
+        - Parameters for different outputs don't interfere with each other
+        - The naming scheme correctly distinguishes between outputs
+        """
+        # Create test parameters (err key optional)
+        A_flux = rng.random((model_config["n_flux"], model_config["n_latents"]))
+        b_flux = rng.random((model_config["n_flux"], 1))
+        A_label = rng.random((model_config["n_labels"], model_config["n_latents"]))
+
+        params = {
+            "flux": {"data": [{"A": A_flux}, {"b": b_flux}]},
+            "label": {"data": {"A": A_label}},
+        }
+
+        # Test packing
+        packed = multi_output_model.pack_numpyro_params(params)
+        expected_keys = {"flux:0:A", "flux:1:b", "label:A"}
+
+        assert set(packed.keys()) == expected_keys
+        assert np.allclose(packed["flux:0:A"], A_flux)
+        assert np.allclose(packed["flux:1:b"], b_flux)
+        assert np.allclose(packed["label:A"], A_label)
+
+        # Test unpacking
+        unpacked = multi_output_model.unpack_numpyro_params(packed)
+
+        # Check flux (TransformSequence - list structure)
+        assert isinstance(unpacked["flux"]["data"], list | tuple)
+        assert len(unpacked["flux"]["data"]) == 2
+        assert np.allclose(unpacked["flux"]["data"][0]["A"], A_flux)
+        assert np.allclose(unpacked["flux"]["data"][1]["b"], b_flux)
+
+        # Check label (single transform - dict structure)
+        assert isinstance(unpacked["label"]["data"], dict)
+        assert np.allclose(unpacked["label"]["data"]["A"], A_label)
+
+        # Check error parameters are empty but properly structured
+        assert unpacked["flux"]["err"] == {}
+        assert unpacked["label"]["err"] == {}
+
+    def test_round_trip_conversion_integrity(
+        self, transform_sequence_with_err_model, model_config, rng
+    ):
+        """Test that pack → unpack → pack preserves the original parameter structure.
+
+        This test validates the mathematical integrity of the parameter conversion system:
+        - Original parameter structure is perfectly preserved through round-trip conversion
+        - No data is lost or corrupted during the conversion process
+        - Floating-point precision is maintained within reasonable tolerances
+        - The conversion process is mathematically invertible
+
+        This is critical for ensuring that optimization results can be reliably
+        converted between formats without introducing numerical errors.
+        """
+        # Create original parameters with both data and error components
+        A = rng.random((model_config["n_flux"], model_config["n_latents"]))
+        b = rng.random((model_config["n_flux"], 1))
+        err_b = rng.random((1,))  # Note: different parameter name but could conflict
+
+        orig_params = {
+            "flux": {
+                "data": [{"A": A}, {"b": b}],
+                "err": {"scale": err_b},
+            }
+        }
+
+        # Round trip: pack → unpack → pack
+        packed = transform_sequence_with_err_model.pack_numpyro_params(orig_params)
+        unpacked = transform_sequence_with_err_model.unpack_numpyro_params(packed)
+        repacked = transform_sequence_with_err_model.pack_numpyro_params(unpacked)
+
+        # Verify perfect round-trip conversion
+        assert set(packed.keys()) == set(repacked.keys())
+        for key in packed:
+            assert np.allclose(packed[key], repacked[key])
+
+    def test_missing_parameters_handling(
+        self, single_transform_model, model_config, rng
+    ):
+        """Test graceful handling of missing parameters with skip_missing flag.
+
+        This test validates the robustness of the unpacking system when dealing with
+        incomplete parameter sets:
+        - With skip_missing=True: missing parameters are gracefully ignored
+        - With skip_missing=False: missing parameters raise clear KeyError exceptions
+        - Partial parameter sets are handled without corrupting existing data
+        - Error messages are informative for debugging missing parameters
+
+        This functionality is important for incremental parameter loading and
+        debugging optimization issues.
+        """
+        # Create complete parameter set
+        complete_packed = {
+            "flux:A": rng.random((model_config["n_flux"], model_config["n_latents"]))
+        }
+
+        # Should handle complete parameters without issue
+        unpacked = single_transform_model.unpack_numpyro_params(
+            complete_packed, skip_missing=False
+        )
+
+        assert "flux" in unpacked
+        assert "data" in unpacked["flux"]
+        assert "A" in unpacked["flux"]["data"]
+        assert unpacked["flux"]["err"] == {}
+
+        # Test with truly empty parameters - this should work with skip_missing
+        empty_packed = {}
+        unpacked_skipped = single_transform_model.unpack_numpyro_params(
+            empty_packed, skip_missing=True
+        )
+        # With skip_missing and no parameters, we get an empty dict (no outputs created)
+        assert unpacked_skipped == {}

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,9 +1,11 @@
 import jax.numpy as jnp
 import numpy as np
 import numpyro.distributions as dist
+import pytest
 
 import pollux as plx
 from pollux.models.transforms import (
+    FunctionTransform,
     LinearTransform,
     OffsetTransform,
     TransformSequence,
@@ -76,9 +78,13 @@ def test_transform_sequence():
     tmp = np.array([A @ latents[i] for i in range(n_stars)])
     tmp += b
 
-    tmp2 = trans.apply(jnp.array(latents), t0_A=A, t1_b=b)
-
+    # Test new parameter format with *args (list of dicts)
+    tmp2 = trans.apply(jnp.array(latents), {"A": A}, {"b": b})
     assert np.allclose(tmp2, tmp)
+
+    # Test new flat parameter format with "{index}:{param}" naming
+    tmp3 = trans.apply(jnp.array(latents), **{"0:A": A, "1:b": b})
+    assert np.allclose(tmp3, tmp)
 
 
 def test_transform_sequence_priors():
@@ -106,10 +112,142 @@ def test_transform_sequence_priors():
     tmp = np.array([A @ latents[i] for i in range(n_stars)])
     tmp += b
 
-    params = {"mags": {"t0_A": A, "t1_b": b}}
+    # Test new parameter format with list of dicts
+    params = {"mags": [{"A": A}, {"b": b}]}
 
     model = plx.LuxModel(latent_size=n_latents)
     model.register_output("mags", trans)
     out = model.predict_outputs(latents, params)
 
     assert np.allclose(out["mags"], tmp)
+
+    # Test new flat parameter format
+    params_flat = {"mags": {"0:A": A, "1:b": b}}
+    out_flat = model.predict_outputs(latents, params_flat)
+    assert np.allclose(out_flat["mags"], tmp)
+
+
+def test_transform_sequence_new_parameter_structure():
+    """Test the new tuple-based parameter structure in TransformSequence."""
+    n_stars = 64
+    n_out = 8
+
+    trans = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=n_out),
+            OffsetTransform(output_size=n_stars, vmap=False),
+        )
+    )
+
+    # Test that param_priors and param_shapes are properly stored as tuples
+    assert len(trans.param_priors) == 2
+    assert len(trans.param_shapes) == 2
+
+    # First transform (LinearTransform) should have 'A' parameter
+    assert "A" in trans.param_priors[0]
+    assert "A" in trans.param_shapes[0]
+
+    # Second transform (OffsetTransform) should have 'b' parameter
+    assert "b" in trans.param_priors[1]
+    assert "b" in trans.param_shapes[1]
+
+
+def test_transform_sequence_parameter_validation():
+    """Test parameter validation in the new apply method."""
+    n_stars = 16
+    n_latents = 4
+    n_out = 2
+    rng = np.random.default_rng(123)
+
+    trans = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=n_out),
+            OffsetTransform(output_size=n_stars, vmap=False),
+        )
+    )
+
+    latents = jnp.array(rng.random((n_stars, n_latents)))
+    A = rng.random((n_out, n_latents))
+
+    # Test error when wrong number of parameter dictionaries
+    with pytest.raises(ValueError, match="Expected 2 parameter dictionaries"):
+        trans.apply(latents, {"A": A})  # Missing second dict
+
+    # Test error for unsupported parameter naming
+    with pytest.raises(ValueError, match="Unsupported parameter name format"):
+        trans.apply(latents, invalid_param=A)
+
+
+def test_numpyro_parameter_naming_integration():
+    """Test integration with NumPyro parameter naming scheme."""
+    n_stars = 32
+    n_latents = 8
+    n_out = 4
+
+    # Create a simple model with TransformSequence
+    model = plx.LuxModel(latent_size=n_latents)
+    trans = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=n_out),
+            OffsetTransform(
+                output_size=n_out, vmap=False
+            ),  # Fixed: should be n_out, not n_stars
+        )
+    )
+    model.register_output("test", trans)
+
+    # Test that get_expanded_priors returns flat priors with new naming
+    priors = trans.get_expanded_priors(latent_size=n_latents, data_size=n_stars)
+
+    expected_names = {"0:A", "1:b"}
+    assert set(priors.keys()) == expected_names
+
+    # Test shapes
+    assert priors["0:A"].batch_shape == (n_out, n_latents)
+    assert priors["1:b"].batch_shape == (n_out, 1)  # Fixed: should be (n_out, 1)
+
+
+def test_function_transform_in_sequence():
+    """Test FunctionTransform within TransformSequence with new parameter scheme."""
+    n_stars = 16
+    n_latents = 4
+    n_flux = 8
+    rng = np.random.default_rng(789)
+
+    # Create function transform similar to the notebook example
+    def custom_transform(x, p1, p2):
+        return x + p1[:, None] * 0.5 + p2[:, None] * 0.25
+
+    func_trans = FunctionTransform(
+        output_size=n_flux,
+        transform=custom_transform,
+        param_priors={"p1": dist.Normal(0.0, 1.0), "p2": dist.Normal(0.0, 1.0)},
+        param_shapes={"p1": (n_stars,), "p2": (n_stars,)},
+        vmap=False,
+    )
+
+    trans_seq = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=n_flux),
+            func_trans,
+        )
+    )
+
+    latents = jnp.array(rng.random((n_stars, n_latents)))
+    A = rng.random((n_flux, n_latents))
+    p1 = rng.random((n_stars,))
+    p2 = rng.random((n_stars,))
+
+    # Test with new parameter format using *args
+    result = trans_seq.apply(latents, {"A": A}, {"p1": p1, "p2": p2})
+
+    # Verify the computation manually
+    intermediate = A @ latents.T  # Shape: (n_flux, n_stars)
+    expected = intermediate.T + p1[:, None] * 0.5 + p2[:, None] * 0.25
+
+    assert np.allclose(result, expected)
+
+    # Test with flat parameter format
+    result_flat = trans_seq.apply(latents, **{"0:A": A, "1:p1": p1, "1:p2": p2})
+
+    assert np.allclose(result_flat, expected)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -338,7 +338,7 @@ def test_transform_sequence_unpack_with_missing_params():
 
     # Only provide parameters for first transform
     flat_params = {"0:A": rng.random((n_out, n_latents))}
-    unpacked = trans_seq.unpack_params(flat_params)
+    unpacked = trans_seq.unpack_params(flat_params, skip_missing=True)
 
     assert len(unpacked) == 2
     assert "A" in unpacked[0]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -251,3 +251,226 @@ def test_function_transform_in_sequence():
     result_flat = trans_seq.apply(latents, **{"0:A": A, "1:p1": p1, "1:p2": p2})
 
     assert np.allclose(result_flat, expected)
+
+
+def test_transform_sequence_pack_unpack_params():
+    """Test the pack_params and unpack_params methods for parameter conversion.
+
+    Tests basic functionality of packing nested parameter lists into flat dictionaries
+    and vice versa. Verifies round-trip conversion (pack → unpack → original structure)
+    with a two-transform sequence (LinearTransform + OffsetTransform).
+
+    Covers:
+    - Packing: nested list → flat dict with "{index}:{param}" naming
+    - Unpacking: flat dict → nested list structure
+    - Round-trip conversion preserves all parameter data accurately
+    """
+    n_latents = 8
+    n_out = 4
+    rng = np.random.default_rng(456)
+
+    # Create a TransformSequence with multiple transforms
+    trans_seq = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=n_out),
+            OffsetTransform(output_size=n_out, vmap=False),
+        )
+    )
+
+    # Create test parameter values
+    A = rng.random((n_out, n_latents))
+    b = rng.random((n_out, 1))
+
+    # Test packing: nested list -> flat dict
+    nested_params = [
+        {"A": A},
+        {"b": b},
+    ]
+
+    packed = trans_seq.pack_params(nested_params)
+    expected_packed = {"0:A": A, "1:b": b}
+
+    assert set(packed.keys()) == set(expected_packed.keys())
+    assert np.allclose(packed["0:A"], expected_packed["0:A"])
+    assert np.allclose(packed["1:b"], expected_packed["1:b"])
+
+    # Test unpacking: flat dict -> nested list
+    flat_params = {"0:A": A, "1:b": b}
+    unpacked = trans_seq.unpack_params(flat_params)
+
+    assert len(unpacked) == 2
+    assert set(unpacked[0].keys()) == {"A"}
+    assert set(unpacked[1].keys()) == {"b"}
+    assert np.allclose(unpacked[0]["A"], A)
+    assert np.allclose(unpacked[1]["b"], b)
+
+    # Test round-trip: pack -> unpack should return original
+    round_trip = trans_seq.unpack_params(trans_seq.pack_params(nested_params))
+    assert len(round_trip) == len(nested_params)
+    for orig, restored in zip(nested_params, round_trip):
+        assert set(orig.keys()) == set(restored.keys())
+        for key in orig:
+            assert np.allclose(orig[key], restored[key])
+
+
+def test_transform_sequence_unpack_with_missing_params():
+    """Test unpacking parameters when some parameters are missing.
+
+    Tests behavior when only some transforms have parameters provided.
+    Ensures empty dictionaries are created for transforms without parameters,
+    demonstrating robust handling of partial parameter sets.
+
+    Covers:
+    - Graceful handling of missing parameters for some transforms
+    - Empty dictionary creation for transforms without provided parameters
+    - No errors when parameter coverage is incomplete
+    """
+    n_out = 4
+    n_latents = 8
+    rng = np.random.default_rng(123)
+
+    trans_seq = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=n_out),
+            OffsetTransform(output_size=n_out, vmap=False),
+        )
+    )
+
+    # Only provide parameters for first transform
+    flat_params = {"0:A": rng.random((n_out, n_latents))}
+    unpacked = trans_seq.unpack_params(flat_params)
+
+    assert len(unpacked) == 2
+    assert "A" in unpacked[0]
+    assert len(unpacked[1]) == 0  # Second transform should have empty dict
+
+
+def test_transform_sequence_unpack_with_extra_params():
+    """Test unpacking parameters with extra parameters that don't match any transform.
+
+    Tests robustness when invalid parameter names are provided, including parameters
+    with invalid transform indices and non-indexed parameter names. Ensures the
+    unpacking process ignores invalid parameters gracefully without errors.
+
+    Covers:
+    - Invalid transform indices (beyond sequence length) are ignored
+    - Non-indexed parameter names (missing ":") are ignored silently
+    - Only valid parameters matching existing transforms are unpacked
+    - Robust error handling for malformed parameter names
+    """
+    n_out = 4
+    n_latents = 8
+    rng = np.random.default_rng(789)
+
+    trans_seq = TransformSequence(transforms=(LinearTransform(output_size=n_out),))
+
+    # Include valid parameter and some invalid ones
+    flat_params = {
+        "0:A": rng.random((n_out, n_latents)),
+        "5:invalid": rng.random((2, 2)),  # Invalid transform index
+        "not_indexed": rng.random((3, 3)),  # No index format
+    }
+
+    unpacked = trans_seq.unpack_params(flat_params)
+
+    # Should only unpack valid parameters
+    assert len(unpacked) == 1
+    assert "A" in unpacked[0]
+    # Invalid parameters should be ignored silently
+
+
+def test_transform_sequence_pack_empty_dicts():
+    """Test packing when some parameter dictionaries are empty.
+
+    Tests the packing process when some transforms in the sequence have empty
+    parameter dictionaries. Ensures that only non-empty parameters are included
+    in the flat output dictionary, demonstrating efficient handling of sparse
+    parameter sets.
+
+    Covers:
+    - Empty parameter dictionaries are handled gracefully
+    - Only non-empty parameters appear in packed output
+    - No spurious entries for transforms without parameters
+    """
+    n_out = 4
+    rng = np.random.default_rng(456)
+
+    trans_seq = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=n_out),
+            OffsetTransform(output_size=n_out, vmap=False),
+        )
+    )
+
+    # First transform has parameters, second is empty
+    nested_params = [
+        {"A": rng.random((n_out, 4))},
+        {},  # Empty dict for second transform
+    ]
+
+    packed = trans_seq.pack_params(nested_params)
+
+    # Should only have parameters from first transform
+    assert set(packed.keys()) == {"0:A"}
+
+
+def test_transform_sequence_three_transforms_pack_unpack():
+    """Test pack/unpack with three transforms to ensure indexing works correctly.
+
+    Tests parameter conversion with a more complex three-transform sequence including
+    a custom FunctionTransform. Verifies correct indexing with multiple transforms
+    (0:A, 1:scale, 2:b) and tests the full round-trip conversion with complex
+    parameter structures to ensure scalability.
+
+    Covers:
+    - Correct indexing scheme for sequences of any length (0, 1, 2, ...)
+    - Integration with custom FunctionTransform parameters
+    - Multiple parameter types (matrices, scalars, vectors)
+    - Full round-trip conversion preserves complex parameter structures
+    - Scalability beyond simple two-transform cases
+    """
+    n_latents = 4
+    n_out = 3
+    rng = np.random.default_rng(321)
+
+    # Create function transform for middle position
+    def simple_func(x, scale):
+        return x * scale
+
+    func_trans = FunctionTransform(
+        output_size=n_out,
+        transform=simple_func,
+        param_priors={"scale": dist.Normal(1.0, 0.1)},
+        param_shapes={"scale": (1,)},
+        vmap=False,
+    )
+
+    trans_seq = TransformSequence(
+        transforms=(
+            LinearTransform(output_size=n_out),
+            func_trans,
+            OffsetTransform(output_size=n_out, vmap=False),
+        )
+    )
+
+    # Create parameters for all three transforms
+    A = rng.random((n_out, n_latents))
+    scale = rng.random((1,))
+    b = rng.random((n_out, 1))
+
+    nested_params = [
+        {"A": A},
+        {"scale": scale},
+        {"b": b},
+    ]
+
+    # Test pack -> unpack round trip
+    packed = trans_seq.pack_params(nested_params)
+    expected_keys = {"0:A", "1:scale", "2:b"}
+    assert set(packed.keys()) == expected_keys
+
+    unpacked = trans_seq.unpack_params(packed)
+    assert len(unpacked) == 3
+    assert np.allclose(unpacked[0]["A"], A)
+    assert np.allclose(unpacked[1]["scale"], scale)
+    assert np.allclose(unpacked[2]["b"], b)


### PR DESCRIPTION
I found a bug in the logic for packing/unpacking parameters in which parameters with the same name in data/err transforms would overwrite one another. 

This PR redesigns some of the packing/unpacking logic, adds unit tests, and redesigns the way parameters for transform sequences are stored.